### PR TITLE
Adding OWASP AI exchange as an AISec resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Backdoors/neural trojans (same as for non-ML systems), adversarial evasion (pert
 * [MITRE ATLAS](https://atlas.mitre.org/)
 * [AI Incident Database](https://incidentdatabase.ai/)
 * [OWASP Top 10 for LLMs](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+* [OWASP AI Exchange](https://owaspai.org) - comprehensive AI security guide with 300+ pages of practical guidance on protecting AI systems
 * [Guidelines for secure AI system development](https://www.ncsc.gov.uk/files/Guidelines-for-secure-AI-system-development.pdf)
 
 ## Security tools and techniques


### PR DESCRIPTION
Adds the OWASP AI Exchange (https://owaspai.org) to the Taxonomies and frameworks section. This flagship OWASP project provides 300+ pages of practical AI security guidance, covering threats, controls, and risk analysis.